### PR TITLE
fix: add default value for removed values

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func (e *Exporter) collectPlugins(name string, section string, data interface{},
 	plugins := stats[section].([]interface{})
 	for _, p := range plugins {
 		plugin := p.(map[string]interface{})
-		labels := prometheus.Labels{}
+		labels := prometheus.Labels{"id": "", "name": ""}
 
 		if id, exists := plugin["id"]; exists {
 			labels["id"] = id.(string)


### PR DESCRIPTION
Hi,

During my previous PR (#9), I moved some labels (`id` and `name`) in a conditional block without adding default values. The result is, instead of panicking when the value is not found (and restarting), the exporter just not work returning only a `500` for each scrapping.
```
collected metric logstash_pipeline_plugins_outputs_sniff_requests label:<name:"id" value:"b8f8a1f712f2be3b208dbfa8cd45d59a11ede591883e9fa05a197d0ebd3f2312" > label:<name:"pipeline" value:"main" > untyped:<value:1 >  has label dimensions inconsistent with previously collected metrics in the same metric family
```

This PR fix this issue, sorry for that mistake.